### PR TITLE
ui: fix loading indicator when not enough height

### DIFF
--- a/src/components/LessonList.vue
+++ b/src/components/LessonList.vue
@@ -10,9 +10,7 @@
               class="table-header"
               v-for="header in tableHeader"
               :key="header"
-            >
-              {{ header }}
-            </th>
+            >{{ header }}</th>
           </tr>
         </thead>
         <tbody>
@@ -68,7 +66,7 @@ export default class LessonList extends Vue {
 
   bottom = false;
 
-  maxElements = 10;
+  maxElements = 100;
 
   b(s: string, sep: string) {
     if (!s) return "";
@@ -88,7 +86,7 @@ export default class LessonList extends Vue {
   }
 
   moreElements() {
-    this.maxElements = Math.min(this.maxElements + 10, this.data.length);
+    this.maxElements = Math.min(this.maxElements + 100, this.data.length);
   }
 
   @Watch("bottom")
@@ -96,6 +94,12 @@ export default class LessonList extends Vue {
     if (bottom) {
       this.moreElements();
     }
+  }
+
+  @Watch("data")
+  onDataChanged() {
+    this.maxElements = 100;
+    this.selfDiv.scrollTop = 0;
   }
 
   mounted() {

--- a/src/components/LessonList.vue
+++ b/src/components/LessonList.vue
@@ -10,7 +10,9 @@
               class="table-header"
               v-for="header in tableHeader"
               :key="header"
-            >{{ header }}</th>
+            >
+              {{ header }}
+            </th>
           </tr>
         </thead>
         <tbody>


### PR DESCRIPTION
Currently, it is possible that:

* Select a category with only a few courses, and uncheck it (<= 10, not fill whole page)
* Loading indicator never hides

In this way, we show more courses, and reset maximum items on data load, to solve this issue.